### PR TITLE
Add JRuby support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: ruby
 cache: bundler
 rvm:
   - 2.0.0
+  - jruby
 before_install:
   - gem install bundler -v '< 2'
 script:

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -10,6 +10,7 @@ GEM
       tins (~> 1.6)
     docile (1.3.1)
     json (2.1.0)
+    json (2.1.0-java)
     parallel (1.12.1)
     parser (2.5.3.0)
       ast (~> 2.4.0)
@@ -42,6 +43,7 @@ GEM
     yard (0.9.16)
 
 PLATFORMS
+  java
   ruby
 
 DEPENDENCIES
@@ -53,4 +55,4 @@ DEPENDENCIES
   yard (>= 0.9.16)
 
 BUNDLED WITH
-   1.17.1
+   1.17.3


### PR DESCRIPTION
JRuby (tested with v9.1) OpenSSL Cipher behaves slightly differently than the
MRI Ruby Cipher object.  There are two differences that cause this gem to break
when used with JRuby:

 1. Calling cipher's #reset method before a key is loaded causes the JRuby
    cipher to raise an error.  MRI Ruby cipher does not.

 2. MRI Ruby will return a block of ciphertext immediately after BLOCK_LEN
    bytes of data have been placed into the cipher.  In JRuby, it returns a
    block of ciphertext only after BLOCK_LEN+1 bytes.  However if we call
    the cipher #final method, then strip-off the final block of PKCS#7 padding
    at the end, we get an identical result regardless of which version of Ruby
    is used.

Example of MRI Ruby cipher behavior:
```
irb(main):001:0> require 'openssl'; require 'securerandom'
irb(main):002:0> data = ['82ff04a322fcce6bd24c86959b48d548'].pack('H*')
=> "\x82\xFF\x04\xA3\"\xFC\xCEk\xD2L\x86\x95\x9BH\xD5H"
irb(main):003:0> key0 = ['2b7e151628aed2a6abf7158809cf4f3c'].pack('H*')
=> "+~\x15\x16(\xAE\xD2\xA6\xAB\xF7\x15\x88\t\xCFO<"
irb(main):004:0> data.length
=> 16
irb(main):005:0> cipher = OpenSSL::Cipher.new("AES-128-CBC")
=> #<OpenSSL::Cipher:0x00000000f21fc0>
irb(main):006:0> cipher.encrypt
=> #<OpenSSL::Cipher:0x00000000f21fc0>
irb(main):007:0> cipher.key = key0
=> "+~\x15\x16(\xAE\xD2\xA6\xAB\xF7\x15\x88\t\xCFO<"
irb(main):008:0> result = cipher.update(data).unpack('H*')
=> ["7175782ba9976e90ab6df8467890ebac"]
irb(main):009:0> result += cipher.final.unpack('H*')
=> ["7175782ba9976e90ab6df8467890ebac", "77c2fe3a6f69fe266ededdecec919af0"]
```

Example of JRuby Cipher behavior:
```
irb(main):001:0> require 'openssl'; require 'securerandom'
irb(main):002:0> data = ['82ff04a322fcce6bd24c86959b48d548'].pack('H*')
=> "\x82\xFF\x04\xA3\"\xFC\xCEk\xD2L\x86\x95\x9BH\xD5H"
irb(main):003:0> key0 = ['2b7e151628aed2a6abf7158809cf4f3c'].pack('H*')
=> "+~\x15\x16(\xAE\xD2\xA6\xAB\xF7\x15\x88\t\xCFO<"
irb(main):004:0> data.length
=> 16
irb(main):005:0> cipher = OpenSSL::Cipher.new("AES-128-CBC")
=> #<OpenSSL::Cipher:0x16eccb2e>
irb(main):006:0> cipher.encrypt
=> #<OpenSSL::Cipher:0x16eccb2e>
irb(main):007:0> cipher.key = key0
=> "+~\x15\x16(\xAE\xD2\xA6\xAB\xF7\x15\x88\t\xCFO<"
irb(main):008:0> result = cipher.update(data).unpack('H*')
=> [""]
irb(main):009:0> result += cipher.final.unpack('H*')
=> ["", "7175782ba9976e90ab6df8467890ebac77c2fe3a6f69fe266ededdecec919af0"]
```

==============================================

Prior to fix:

```
irb(main):001:0> require 'openssl/cmac'
=> true
irb(main):002:0> require 'base64'
=> true
irb(main):003:0> key = ['2b7e151628aed2a6abf7158809cf4f3c'].pack('H*')
=> "+~\x15\x16(\xAE\xD2\xA6\xAB\xF7\x15\x88\t\xCFO<"
irb(main):004:0> plaintext = 'Some test data goes here.'
=> "Some test data goes here."
irb(main):005:0> cmac = OpenSSL::CMAC.new('AES')
=> #<OpenSSL::CMAC:0x1e1d3956 @keys=[], @cipher=#<OpenSSL::Cipher:0x4f2c9ba6>, @buffer="">
irb(main):006:0> cmac.key = key
OpenSSL::Cipher::CipherError: key not specified
        from org/jruby/ext/openssl/Cipher.java:944:in `reset'
        from /workspace/openssl-cmac-2.0.0/lib/openssl/cmac.rb:130:in `reset'
        from /workspace/openssl-cmac-2.0.0/lib/openssl/cmac.rb:77:in `key='
        from (irb):6:in `<eval>'
        from org/jruby/RubyKernel.java:994:in `eval'
        from org/jruby/RubyKernel.java:1292:in `loop'
        from org/jruby/RubyKernel.java:1114:in `catch'
        from org/jruby/RubyKernel.java:1114:in `catch'
        from /workspace/bin/irb:13:in `<eval>'
        from org/jruby/RubyKernel.java:994:in `eval'
        from /workspace/bin/irb:7:in `<main>'
```

After fix:

```
irb(main):001:0> require 'openssl/cmac'
=> true
irb(main):002:0> require 'base64'
=> true
irb(main):003:0> key = ['2b7e151628aed2a6abf7158809cf4f3c'].pack('H*')
=> "+~\x15\x16(\xAE\xD2\xA6\xAB\xF7\x15\x88\t\xCFO<"
irb(main):004:0> plaintext = 'Some test data goes here.'
=> "Some test data goes here."
irb(main):005:0> cmac = OpenSSL::CMAC.new('AES')
=> #<OpenSSL::CMAC:0x150ab4ed @keys=[], @cipher=#<OpenSSL::Cipher:0x3c435123>, @buffer="">
irb(main):006:0> cmac.key = key
=> "+~\x15\x16(\xAE\xD2\xA6\xAB\xF7\x15\x88\t\xCFO<"
irb(main):007:0> cmac << plaintext
=> #<OpenSSL::CMAC:0x150ab4ed @keys=["+~\x15\x16(\xAE\xD2\xA6\xAB\xF7\x15\x88\t\xCFO<", [251, 238, 214, 24, 53, 113, 51, 102, 124, 133, 224, 143, 114, 54, 168, 222], [247, 221, 172, 48, 106, 226, 102, 204, 249, 11, 193, 30, 228, 109, 81, 59]], @cipher=#<OpenSSL::Cipher:0x3c435123>, @buffer="oes here.">
irb(main):008:0> Base64.encode64(cmac.digest)
=> "pUgRWq1RNRE2mBBJhDhtNA==\n"
```

Lastly, I tested against example#3 from the RFC in both MRI Ruby and JRuby and got the expected value:
```
irb(main):031:0> key = ['2b7e151628aed2a6abf7158809cf4f3c'].pack('H*')
=> "+~\x15\x16(\xAE\xD2\xA6\xAB\xF7\x15\x88\t\xCFO<"
irb(main):032:0> plaintext = ['6bc1bee22e409f96e93d7e117393172aae2d8a571e03ac9c9eb76fac45af8e5130c81c46a35ce411'].pack('H*')
=> "k\xC1\xBE\xE2.@\x9F\x96\xE9=~\x11s\x93\x17*\xAE-\x8AW\x1E\x03\xAC\x9C\x9E\xB7o\xACE\xAF\x8EQ0\xC8\x1CF\xA3\\\xE4\x11"
irb(main):033:0> cmac = OpenSSL::CMAC.new('AES')
=> #<OpenSSL::CMAC:0x4275c20c @keys=[], @cipher=#<OpenSSL::Cipher:0x7c56e013>, @buffer="">
irb(main):034:0> cmac.key = key
=> "+~\x15\x16(\xAE\xD2\xA6\xAB\xF7\x15\x88\t\xCFO<"
irb(main):035:0> cmac << plaintext
=> #<OpenSSL::CMAC:0x4275c20c @keys=["+~\x15\x16(\xAE\xD2\xA6\xAB\xF7\x15\x88\t\xCFO<", [251, 238, 214, 24, 53, 113, 51, 102, 124, 133, 224, 143, 114, 54, 168, 222], [247, 221, 172, 48, 106, 226, 102, 204, 249, 11, 193, 30, 228, 109, 81, 59]], @cipher=#<OpenSSL::Cipher:0x7c56e013>, @buffer="0\xC8\x1CF\xA3\\\xE4\x11">
irb(main):036:0> digest = cmac.digest
=> "\xDF\xA6gG\xDE\x9A\xE600\xCA2a\x14\x97\xC8'"
irb(main):037:0> digest.unpack('H*')
=> ["dfa66747de9ae63030ca32611497c827"]
```